### PR TITLE
MultiPoint

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["SimonDanisch <sdanisch@gmail.com>"]
 version = "0.1.2"
 
 [deps]
-GeometryTypes = "4d00f742-c7ba-57c2-abde-4428a4b178cb"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
@@ -14,7 +13,8 @@ julia = ">= 1.1"
 
 [extras]
 Query = "1a8c2f83-1ff3-5112-b086-8aa67b057ba1"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Query"]
+test = ["Test", "Query", "Random"]

--- a/src/basic_types.jl
+++ b/src/basic_types.jl
@@ -265,10 +265,9 @@ struct MultiPolygon{
         Element <: AbstractPolygon{Dim, T},
         A <: AbstractVector{Element}
     } <: AbstractVector{Element}
+
     polygons::A
 end
-
-
 
 function MultiPolygon(polygons::AbstractVector{P}; kw...) where P <: AbstractPolygon{Dim, T} where {Dim, T}
     MultiPolygon(meta(polygons; kw...))
@@ -283,8 +282,31 @@ struct MultiLineString{
         A <: AbstractVector{Element}
     } <: AbstractVector{Element}
 
-    polygons::A
+    linestrings::A
 end
+
+function MultiLineString(linestrings::AbstractVector{L}; kw...) where L <: AbstractVector{LineP{Dim, T, P}} where {Dim, T, P}
+    MultiLineString(meta(linestrings; kw...))
+end
+
+Base.getindex(ms::MultiLineString, i) = ms.linestrings[i]
+Base.size(ms::MultiLineString) = size(ms.linestrings)
+
+struct MultiPoint{
+    Dim, T <: Real,
+    Element <: Point{Dim, T},
+    A <: AbstractVector{Element}
+} <: AbstractVector{Element}
+
+    points::A
+end
+
+function MultiPoint(points::AbstractVector{P}; kw...) where P <: AbstractPoint{Dim, T} where {Dim, T}
+    MultiPoint(meta(points; kw...))
+end
+
+Base.getindex(mpt::MultiPoint, i) = mpt.points[i]
+Base.size(mpt::MultiPoint) = size(mpt.points)
 
 struct Mesh{
         Dim, T <: Real,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,9 @@
 using GeometryBasics
-using GeometryBasics: Polygon, MultiPolygon, Point, LineFace, Polytope, Line
+using GeometryBasics: LineFace, Polytope, Line
+using GeometryBasics: Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon
 using GeometryBasics: Simplex, connect, Triangle, NSimplex, Tetrahedron
 using GeometryBasics: QuadFace, hascolumn, getcolumn, metafree, coordinates, TetrahedronFace
-using GeometryBasics: TupleView, TriangleFace, SimplexFace, LineString, Mesh, meta, column_names
+using GeometryBasics: TupleView, TriangleFace, SimplexFace, Mesh, meta, column_names
 using Test, Random, Query, StructArrays, Tables
 using StaticArrays
 
@@ -233,6 +234,36 @@ end
         mesh = Mesh(points, faces)
         @test mesh == [Tetrahedron(points...)]
 
+    end
+
+    @testset "Multi geometries" begin
+        # coordinates from https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry#Geometric_objects
+        points = Point{2, Int}[(10, 40), (40, 30), (20, 20), (30, 10)]
+        multipoint = MultiPoint(points)
+        @test size(multipoint) === size(points)
+        @test multipoint[3] === points[3]
+        
+        linestring1 = LineString(Point{2, Int}[(10, 10), (20, 20), (10, 40)])
+        linestring2 = LineString(Point{2, Int}[(40, 40), (30, 30), (40, 20), (30, 10)])
+        multilinestring = MultiLineString([linestring1, linestring2])
+        @test size(multilinestring) === (2,)
+        @test multilinestring[1] === linestring1
+        @test multilinestring[2] === linestring2
+        
+        polygon11 = Polygon(Point{2, Int}[(30, 20), (45, 40), (10, 40), (30, 20)])
+        polygon12 = Polygon(Point{2, Int}[(15, 5), (40, 10), (10, 20), (5, 10), (15, 5)])
+        multipolygon1 = MultiPolygon([polygon11, polygon12])
+        @test size(multipolygon1) === (2,)
+        @test multipolygon1[1] === polygon11
+        @test multipolygon1[2] === polygon12
+        
+        polygon21 = Polygon(Point{2, Int}[(40, 40), (20, 45), (45, 30), (40, 40)])
+        polygon22 = Polygon(LineString(Point{2, Int}[(20, 35), (10, 30), (10, 10), (30, 5), (45, 20), (20, 35)]),
+            [LineString(Point{2, Int}[(30, 20), (20, 15), (20, 25), (30, 20)])])
+        multipolygon2 = MultiPolygon([polygon21, polygon22])
+        @test size(multipolygon2) === (2,)
+        @test multipolygon2[1] === polygon21
+        @test multipolygon2[2] === polygon22
     end
 
 end


### PR DESCRIPTION
From https://geojson.org/: GeoJSON supports the following geometry types: Point, LineString, Polygon, MultiPoint, MultiLineString, and MultiPolygon.

In this package, the only one of those not here is MultiPoint. Or did you leave it out on purpose?